### PR TITLE
[footer] - department and not unit

### DIFF
--- a/docs/footer.html
+++ b/docs/footer.html
@@ -2,6 +2,6 @@
 <hr />
 <p style="font-family:verdana">About us</p>
 
-<p style="text-align: left;"> <a href="https://www.worldbank.org/en/research/dime">DIME</a> is the impact evaluation unit of the World Bank Research Group. Part of DIME’s mission is to intensify the production of and access to public goods that improve the quantity and quality of global development research, while lowering the costs of doing IE for the entire research community. This Library is developed and maintained by the DIME Analytics team, a new initiative to provide data quality assurance to all DIME impact evaluations.</p>
+<p style="text-align: left;"> <a href="https://www.worldbank.org/en/research/dime">DIME</a> is the impact evaluation department of the World Bank Research Group. Part of DIME’s mission is to intensify the production of and access to public goods that improve the quantity and quality of global development research, while lowering the costs of doing IE for the entire research community. This Library is developed and maintained by the DIME Analytics team, a new initiative to provide data quality assurance to all DIME impact evaluations.</p>
 
 &nbsp;


### PR DESCRIPTION
DIME is no longer a unit. Maybe make sure this was the only location we called DIME a unit. Was this copied from another visual library landing page?